### PR TITLE
Fix compactors continuing to run when full

### DIFF
--- a/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -363,8 +363,13 @@ public class FurnCraftChestFactory extends Factory {
 						deactivate();
 						return;
 					} else {
-						currentRecipe.applyEffect(getInventory(), this);
-						runCount.put(currentRecipe, runCount.get(currentRecipe) + 1);
+						if (currentRecipe.applyEffect(getInventory(), this)) {
+							runCount.put(currentRecipe, runCount.get(currentRecipe) + 1);
+						} else {
+							sendActivatorMessage(ChatColor.RED + currentRecipe.getName() + " in " + name + " deactivated because it ran out of storage space");
+							deactivate();
+							return;
+						}
 					}
 					currentProductionTimer = 0;
 					if (currentRecipe instanceof RepairRecipe && rm.atFullHealth()) {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/AOERepairRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/AOERepairRecipe.java
@@ -136,7 +136,7 @@ public class AOERepairRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		Chest c = (Chest) i.getHolder();
 		Location loc = c.getLocation();
 		List<FurnCraftChestFactory> facs = getNearbyFactoriesSortedByDistance(loc);
@@ -174,6 +174,7 @@ public class AOERepairRecipe extends InputRecipe {
 				break;
 			}
 		}
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/CompactingRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/CompactingRecipe.java
@@ -59,7 +59,7 @@ public class CompactingRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		if (input.isContainedIn(i)) {
 			ItemMap im = new ItemMap(i);
@@ -78,7 +78,7 @@ public class CompactingRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
-
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/DecompactingRecipe.java
@@ -45,7 +45,7 @@ public class DecompactingRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		if (input.isContainedIn(i)) {
 			for (ItemStack is : i.getContents()) {
@@ -65,6 +65,8 @@ public class DecompactingRecipe extends InputRecipe {
 									}
 								}
 							}
+						} else { // does not fit in chest
+							return false;
 						}
 						break;
 					}
@@ -72,6 +74,7 @@ public class DecompactingRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/DeterministicEnchantingRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/DeterministicEnchantingRecipe.java
@@ -84,7 +84,7 @@ public class DeterministicEnchantingRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		if (input.removeSafelyFrom(i)) {
 			ItemStack toolio = tool.getItemStackRepresentation().get(0);
@@ -100,6 +100,7 @@ public class DeterministicEnchantingRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/DummyParsingRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/DummyParsingRecipe.java
@@ -17,7 +17,8 @@ public class DummyParsingRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/FactoryMaterialReturnRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/FactoryMaterialReturnRecipe.java
@@ -71,7 +71,7 @@ public class FactoryMaterialReturnRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, final FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, final FurnCraftChestFactory fccf) {
 		FactoryMod.getInstance().getManager().removeFactory(fccf);
 		for (Block b : fccf.getMultiBlockStructure().getRelevantBlocks()) {
 			b.setType(Material.AIR);
@@ -98,6 +98,7 @@ public class FactoryMaterialReturnRecipe extends InputRecipe {
 						dropLoc.getWorld().dropItemNaturally(dropLoc, new ItemStack(Material.CHEST));
 					}
 				}, 1L);
+		return true;
 	}
 
 	public double getFactor() {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/IRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/IRecipe.java
@@ -44,8 +44,9 @@ public interface IRecipe {
 	 *            Inventory which contains the materials to work with
 	 * @param f
 	 *            Factory which is run
+	 * @return true if the recipe could be run; false otherwise (e.g: not enough storage space)
 	 */
-	public void applyEffect(Inventory i, FurnCraftChestFactory f);
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory f);
 
 	/**
 	 * Each implementation of this class has to specify a unique identifier,

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/LoreEnchantRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/LoreEnchantRecipe.java
@@ -92,7 +92,7 @@ public class LoreEnchantRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		if (input.removeSafelyFrom(i)) {
 			ItemStack toolio = tool.getItemStackRepresentation().get(0);
@@ -117,6 +117,7 @@ public class LoreEnchantRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	private boolean hasStackRequiredLore(ItemStack is) {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintBookRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintBookRecipe.java
@@ -50,7 +50,7 @@ public class PrintBookRecipe extends PrintingPressRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 
 		ItemStack printingPlateStack = getPrintingPlateItemStack(i, this.printingPlate);
@@ -66,6 +66,7 @@ public class PrintBookRecipe extends PrintingPressRecipe {
 		}
 
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	protected ItemStack createBook(ItemStack printingPlateStack, int amount) {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintNoteRecipe.java
@@ -64,7 +64,7 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 	}	
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 
 		ItemStack printingPlateStack = getPrintingPlateItemStack(i, getPrintingPlate());
@@ -87,6 +87,7 @@ public class PrintNoteRecipe extends PrintBookRecipe {
 		}
 
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	private BookInfo getBookInfo(ItemStack printingPlateStack) {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateRecipe.java
@@ -45,7 +45,7 @@ public class PrintingPlateRecipe extends PrintingPressRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 
 		ItemStack book = getBook(i);
@@ -76,6 +76,7 @@ public class PrintingPlateRecipe extends PrintingPressRecipe {
 		}
 
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	private ItemStack addTags(Inventory i, String serialNumber, ItemStack is) {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/ProductionRecipe.java
@@ -116,7 +116,7 @@ public class ProductionRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		ItemMap toRemove = input.clone();
 		ItemMap toAdd;
@@ -141,6 +141,7 @@ public class ProductionRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 	
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/PylonRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/PylonRecipe.java
@@ -32,19 +32,20 @@ public class PylonRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		if (!input.isContainedIn(i)) {
-			return;
+			return false;
 		}
 		ItemMap actualOutput = getCurrentOutput();
 		if (!actualOutput.fitsIn(i)) {
-			return;
+			return false;
 		}
 		if (input.removeSafelyFrom(i)) {
 			for (ItemStack is : actualOutput.getItemStackRepresentation()) {
 				i.addItem(is);
 			}
 		}
+		return true;
 	}
 
 	public static void setGlobalLimit(int limit) {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomEnchantingRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomEnchantingRecipe.java
@@ -94,7 +94,7 @@ public class RandomEnchantingRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		for (ItemStack is : input.getItemStackRepresentation()) {
 			i.removeItem(is);
@@ -116,6 +116,7 @@ public class RandomEnchantingRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomOutputRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/RandomOutputRecipe.java
@@ -48,7 +48,7 @@ public class RandomOutputRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		ItemMap toRemove = input.clone();
 		ItemMap toAdd = null;
@@ -65,7 +65,7 @@ public class RandomOutputRecipe extends InputRecipe {
 		}
 		if (toAdd == null) {
 			FactoryMod.getInstance().warning("Unable to find a random item to output. Recipe execution was cancelled," + fccf.getLogData());
-			return;
+			return false;
 		}
 		if (toRemove.isContainedIn(i)) {
 			if (toRemove.removeSafelyFrom(i)) {
@@ -75,6 +75,7 @@ public class RandomOutputRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	public Map<ItemMap, Double> getOutputs() {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/RecipeScalingUpgradeRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/RecipeScalingUpgradeRecipe.java
@@ -27,10 +27,10 @@ public class RecipeScalingUpgradeRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		if (toUpgrade == null || !fccf.getRecipes().contains(toUpgrade)) {
-			return;
+			return false;
 		}
 		ItemMap toRemove = input.clone();
 		if (toRemove.isContainedIn(i)) {
@@ -50,6 +50,7 @@ public class RecipeScalingUpgradeRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	public void setUpgradedRecipe(ProductionRecipe rec) {

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/RepairRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/RepairRecipe.java
@@ -47,7 +47,7 @@ public class RepairRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logBeforeRecipeRun(i, fccf);
 		if (enoughMaterialAvailable(i)) {
 			if (input.removeSafelyFrom(i)) {
@@ -60,6 +60,7 @@ public class RepairRecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 	
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/Upgraderecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/Upgraderecipe.java
@@ -30,7 +30,7 @@ public class Upgraderecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory i, FurnCraftChestFactory fccf) {
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory fccf) {
 		logAfterRecipeRun(i, fccf);
 		if (input.isContainedIn(i)) {
 			if (input.removeSafelyFrom(i)) {
@@ -42,6 +42,7 @@ public class Upgraderecipe extends InputRecipe {
 			}
 		}
 		logAfterRecipeRun(i, fccf);
+		return true;
 	}
 
 	@Override

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/WordBankRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/WordBankRecipe.java
@@ -47,10 +47,10 @@ public class WordBankRecipe extends InputRecipe {
 	}
 
 	@Override
-	public void applyEffect(Inventory inventory, FurnCraftChestFactory factory) {
+	public boolean applyEffect(Inventory inventory, FurnCraftChestFactory factory) {
 		ItemStack toApply = inventory.getItem(0);
 		if (!ItemAPI.isValidItem(toApply)) {
-			return;
+			return false;
 		}
 		ItemMap input = new ItemMap();
 		for (int i = 1; i < inventory.getSize(); i++) {
@@ -62,6 +62,7 @@ public class WordBankRecipe extends InputRecipe {
 			inventory.setItem(i, null);
 		}
 		ItemAPI.setDisplayName(toApply, getHash(input));
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
This changes stops compactors when there is not enough space left in the chests and prints a message when that happens. (see  #10)

This is done by adding a boolean return value to the applyEffect() method of "IRecipe" interface and updating it for derived classes.
This return value is checked by the `FurnCraftChestFactory` class in its `run()` method. 

The proposed behavior is to deactivate the factory when the recipe fails and print a warning message. 
The `DecompactingRecipe` and the `PylonRecipe` are the only recipe that check and return false when the chest is full (the one in PylonRecipe was already testing if the output fit in and was returning if that was the case. Changing that wasn't really hard). Other recipes do not currently test this condition but it's not a difficult fix.

It's also worth noting that this behavior *might* break some existing devices: For instance, someone could use a hopper to evacuate decompacted items. The hopper rate wouldn't be able to follow the factory's rate but it'd still eventually work without deleting anything as the compactor would simply loop the recipe. With the new behavior, such systems would break. It's not a major regression but it might be worth considering.
