### PR TITLE
1) View base factory recipes on unbuilt factories 2) More helpful fuel error message

### DIFF
--- a/src/main/java/com/github/igotyou/FactoryMod/FactoryModManager.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/FactoryModManager.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.github.igotyou.FactoryMod.utility.FactoryModGUI;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -248,6 +249,8 @@ public class FactoryModManager {
 							}
 						} else {
 							p.sendMessage(ChatColor.RED + "There is no factory with the given creation materials");
+//							FactoryModGUI gui = new FactoryModGUI(p);
+//							gui.showFactoryOverview(true);
 						}
 					}
 					return;

--- a/src/main/java/com/github/igotyou/FactoryMod/FactoryModManager.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/FactoryModManager.java
@@ -249,8 +249,8 @@ public class FactoryModManager {
 							}
 						} else {
 							p.sendMessage(ChatColor.RED + "There is no factory with the given creation materials");
-//							FactoryModGUI gui = new FactoryModGUI(p);
-//							gui.showFactoryOverview(true);
+							FactoryModGUI gui = new FactoryModGUI(p);
+							gui.showFactoryOverview(true);
 						}
 					}
 					return;

--- a/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -169,8 +169,7 @@ public class FurnCraftChestFactory extends Factory {
 			if (p != null) {
 				ItemStack fuel = ((FurnacePowerManager) pm).getFuel().clone();
 				if (fuel != null) {
-					String fuelName = ItemNames.getItemName(fuel);
-					p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel (" + fuelName.toLowerCase() + ") in the furnace");
+					p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel (" + ItemNames.getItemName(fuel) + ") in the furnace");
 				}else{
 					p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel in the furnace");
 				}

--- a/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/factories/FurnCraftChestFactory.java
@@ -38,6 +38,7 @@ import com.github.igotyou.FactoryMod.utility.LoggingUtils;
 import vg.civcraft.mc.citadel.ReinforcementLogic;
 import vg.civcraft.mc.citadel.model.Reinforcement;
 import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.civmodcore.api.ItemNames;
 import vg.civcraft.mc.namelayer.permission.PermissionType;
 
 /**
@@ -166,7 +167,13 @@ public class FurnCraftChestFactory extends Factory {
 		//ensure we have fuel
 		if (!pm.powerAvailable(1)) {
 			if (p != null) {
-				p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel in the furnace");
+				ItemStack fuel = ((FurnacePowerManager) pm).getFuel().clone();
+				if (fuel != null) {
+					String fuelName = ItemNames.getItemName(fuel);
+					p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel (" + fuelName.toLowerCase() + ") in the furnace");
+				}else{
+					p.sendMessage(ChatColor.RED + "Failed to activate factory, there is no fuel in the furnace");
+				}
 			}
 			return;
 		}

--- a/src/main/java/com/github/igotyou/FactoryMod/powerManager/FurnacePowerManager.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/powerManager/FurnacePowerManager.java
@@ -73,4 +73,8 @@ public class FurnacePowerManager implements IPowerManager {
 		return new ItemMap(((Furnace) furnace.getState()).getInventory()).getAmount(fuel);
 	}
 
+	public ItemStack getFuel() {
+		return fuel;
+	}
+
 }


### PR DESCRIPTION
1. #19 (Note that factory creation attempt block breaks in creative mode are not cancelled though probably should be)
2. Show required fuel type whenever a factory fails to activate due to lack of fuel


