### PR TITLE
Add PlayerHeadRecipe

### DIFF
--- a/src/main/java/com/github/igotyou/FactoryMod/ConfigParser.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/ConfigParser.java
@@ -52,6 +52,7 @@ import com.github.igotyou.FactoryMod.recipes.RecipeScalingUpgradeRecipe;
 import com.github.igotyou.FactoryMod.recipes.RepairRecipe;
 import com.github.igotyou.FactoryMod.recipes.Upgraderecipe;
 import com.github.igotyou.FactoryMod.recipes.WordBankRecipe;
+import com.github.igotyou.FactoryMod.recipes.PlayerHeadRecipe;
 import com.github.igotyou.FactoryMod.recipes.scaling.ProductionRecipeModifier;
 import com.github.igotyou.FactoryMod.structures.BlockFurnaceStructure;
 import com.github.igotyou.FactoryMod.structures.FurnCraftChestStructure;
@@ -862,6 +863,9 @@ public class ConfigParser {
 			}
 			int wordCount = config.getInt("word_count", 2);
 			result = new WordBankRecipe(identifier, name, productionTime, key, words, colors, wordCount);
+			break;
+		case "PLAYERHEAD":
+			result = new PlayerHeadRecipe(identifier, name, productionTime, input);
 			break;
 		default:
 			plugin.severe("Could not identify type " + config.getString("type") + " as a valid recipe identifier");

--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/PlayerHeadRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/PlayerHeadRecipe.java
@@ -1,0 +1,81 @@
+package com.github.igotyou.FactoryMod.recipes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import com.github.igotyou.FactoryMod.factories.FurnCraftChestFactory;
+
+import vg.civcraft.mc.civmodcore.api.ItemAPI;
+import vg.civcraft.mc.civmodcore.itemHandling.ItemMap;
+
+/***
+ * Outputs a player head belonging to a random player who is connected to the server when the recipe is run
+ */
+public class PlayerHeadRecipe extends InputRecipe {
+	public PlayerHeadRecipe(String identifier, String name, int productionTime, ItemMap inputs) {
+		super(identifier, name, productionTime, inputs);
+	}
+
+	@Override
+	public List<ItemStack> getInputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
+		if (i == null) {
+			return input.getItemStackRepresentation();
+		}
+		return createLoredStacksForInfo(i);
+	}
+
+	@Override
+	public List<ItemStack> getOutputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
+		ItemStack is = new ItemStack(Material.PLAYER_HEAD, 1);
+		ItemAPI.addLore(is,"The player head of a randomly chosen online player");
+		return Collections.singletonList(is);
+	}
+
+	@Override
+	public List<String> getTextualOutputRepresentation(Inventory i, FurnCraftChestFactory fccf) {
+		return Collections.singletonList("The player head of a randomly chosen online player");
+	}
+
+	@Override
+	public Material getRecipeRepresentationMaterial() {
+		return Material.PLAYER_HEAD;
+	}
+
+	@Override
+	public boolean applyEffect(Inventory i, FurnCraftChestFactory f) {
+		logBeforeRecipeRun(i, f);
+		ItemMap toRemove = input.clone();
+		ArrayList<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
+		if (players.isEmpty()) {
+			return false;
+		}
+		if (toRemove.isContainedIn(i)) {
+			if (toRemove.removeSafelyFrom(i)) {
+				Random rand = new Random();
+				Player player = players.get(rand.nextInt(players.size()));
+				ItemStack is = new ItemStack(Material.PLAYER_HEAD, 1);
+				SkullMeta im = (SkullMeta) is.getItemMeta();
+				im.setOwningPlayer(Bukkit.getOfflinePlayer(player.getUniqueId()));
+				im.setDisplayName(player.getDisplayName());
+				is.setItemMeta(im);
+				i.addItem(is);
+			}
+		}
+		logAfterRecipeRun(i, f);
+		return true;
+	}
+
+	@Override
+	public String getTypeIdentifier() {
+		return "PLAYERHEAD";
+	}
+}


### PR DESCRIPTION
 Extends InputRecipe and outputs the player head of a randomly chosen online player. 

Perhaps this mechanic isn't suited as its own recipe type, but it would be neat to have some way to get other players heads that integrates with existing Civ plugins. 
