### PR TITLE
Allow shiftclicking fuel to smelting slot; set container names to factory name

### DIFF
--- a/src/main/java/com/github/igotyou/FactoryMod/commands/Create.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/commands/Create.java
@@ -6,6 +6,9 @@ import java.util.Set;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Chest;
+import org.bukkit.block.Furnace;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -49,6 +52,16 @@ public class Create extends StandaloneCommand {
 					sender.sendMessage(
 							ChatColor.RED + "The required block structure for this factory doesn't exist here");
 					return true;
+				}
+				BlockState chestBS = fccs.getChest().getState();
+				if (((Chest) chestBS).getCustomName() == null) {
+					((Chest) chestBS).setCustomName(fcce.getName());
+					chestBS.update(true);
+				}
+				BlockState furnaceBS = fccs.getFurnace().getState();
+				if (((Furnace) furnaceBS).getCustomName() == null) {
+					((Furnace) furnaceBS).setCustomName(fcce.getName());
+					furnaceBS.update(true);
 				}
 				manager.addFactory(fcce.hatch(fccs, (Player) sender));
 				sender.sendMessage(ChatColor.GREEN + "Created " + egg.getName());

--- a/src/main/java/com/github/igotyou/FactoryMod/utility/FileHandler.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/utility/FileHandler.java
@@ -15,6 +15,8 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.Chest;
+import org.bukkit.block.Furnace;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
@@ -300,6 +302,16 @@ public class FileHandler {
 					}
 				}
 				fac.setAutoSelect(autoSelect);
+				Chest chestBlock = (Chest) (fac.getChest().getState());
+				if (chestBlock.getCustomName() == null) {
+					chestBlock.setCustomName(fac.getName());
+					chestBlock.update(true);
+				}
+				Furnace furnaceBlock = (Furnace) (fac.getFurnace().getState());
+				if (furnaceBlock.getCustomName() == null) {
+					furnaceBlock.setCustomName(fac.getName());
+					furnaceBlock.update(true);
+				}
 				manager.addFactory(fac);
 				counter++;
 				break;

--- a/src/main/java/com/github/igotyou/FactoryMod/utility/FileHandler.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/utility/FileHandler.java
@@ -15,8 +15,6 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.Chest;
-import org.bukkit.block.Furnace;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
@@ -302,16 +300,6 @@ public class FileHandler {
 					}
 				}
 				fac.setAutoSelect(autoSelect);
-				Chest chestBlock = (Chest) (fac.getChest().getState());
-				if (chestBlock.getCustomName() == null) {
-					chestBlock.setCustomName(fac.getName());
-					chestBlock.update(true);
-				}
-				Furnace furnaceBlock = (Furnace) (fac.getFurnace().getState());
-				if (furnaceBlock.getCustomName() == null) {
-					furnaceBlock.setCustomName(fac.getName());
-					furnaceBlock.update(true);
-				}
 				manager.addFactory(fac);
 				counter++;
 				break;


### PR DESCRIPTION
- Valid fuel can be shift-clicked into a factories furnace smelting slot
- Chest and furnaces have their custom name set to the name of the corresponding factory (unless the container already has a custom name, in which case it will not be overwritten). 