### PR TITLE
JSON Printing Plates: Fix escape codes during the check parsing phase

### DIFF
--- a/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateJsonRecipe.java
+++ b/src/main/java/com/github/igotyou/FactoryMod/recipes/PrintingPlateJsonRecipe.java
@@ -45,7 +45,6 @@ public class PrintingPlateJsonRecipe extends PrintingPlateRecipe {
 		String[] pages = String.join("", ((BookMeta) getBook(i).getItemMeta()).getPages()).split("<<PAGE>>");
 
 		for (String page : pages) {
-			page = page.replace("\\", "\\\\");
 			try {
 				Gson gson = new Gson();
 				JsonElement element = gson.fromJson(page, JsonElement.class);


### PR DESCRIPTION
For some reason, I ignored the escape codes while checking if the syntax was valid. Not sure why. That way broke escaped strings (`\"`).